### PR TITLE
Set esbuild `target` browsers using `browserslist`

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -1,9 +1,12 @@
+import browserslist from 'browserslist';
+import chalk from 'chalk';
 import esbuild from 'esbuild';
 import inlineImportPlugin from 'esbuild-plugin-inline-import';
-import sass from 'sass';
 import postcss from 'postcss';
 import postcssVariableCompress from 'postcss-variable-compress';
-import chalk from 'chalk';
+import sass from 'sass';
+
+import resolveTargets from './utils/resolve-targets.mjs';
 
 const mode = process.argv.find((arg) => arg.includes('--mode'))?.split('=')[1];
 const devMode = mode === 'dev';
@@ -24,14 +27,16 @@ const plugins = [
   }),
 ];
 
+const target = resolveTargets(browserslist());
+
 const config = {
   entryPoints: ['./src/index.js'],
   outdir: devMode ? './dev' : './dist',
   bundle: true,
   format: 'esm',
-  target: 'es6',
   minify: !devMode,
   logLevel: 'info',
+  target,
   plugins,
 };
 

--- a/package.json
+++ b/package.json
@@ -21,11 +21,21 @@
     "clean": "rm -rf dist/"
   },
   "devDependencies": {
+    "browserslist": "^4.19.1",
     "chalk": "^5.0.0",
     "esbuild": "^0.14.11",
     "esbuild-plugin-inline-import": "^1.0.1",
     "postcss": "^8.4.5",
     "postcss-variable-compress": "^0.2.5",
     "sass": "^1.47.0"
-  }
+  },
+  "browserslist": [
+    "last 4 chrome major versions",
+    "last 4 edge major versions",
+    "last 4 firefox major versions",
+    "last 1 and_chr major versions",
+    "last 1 and_ff major versions",
+    "last 4 safari major versions",
+    "last 4 ios_saf major versions"
+  ]
 }

--- a/utils/resolve-targets.mjs
+++ b/utils/resolve-targets.mjs
@@ -1,0 +1,45 @@
+/**
+ * Utility function to transform `browserslist` output into supported
+ * browser names and format for esbuild `target` parameter.
+ * @param {Array.<string>} browsersArray - Array of browsers from browserslist
+ * @returns {Array.<string>} Transformed `targets` array for esbuild config
+ */
+const resolveTargets = (browsersArray) => {
+  const alternateNameMap = {
+    and_chr: 'chrome',
+    and_ff: 'firefox',
+    ios_saf: 'ios',
+  };
+
+  const validNames = ['chrome', 'edge', 'firefox', 'ios', 'safari'];
+
+  const transformedArray = browsersArray.map((browser) => {
+    let [browserName, browserVersion] = browser?.split(' ');
+    if (!browserName || !browserVersion) return null;
+
+    if (alternateNameMap.hasOwnProperty(browserName)) {
+      browserName = alternateNameMap[browserName];
+    }
+    if (!validNames.includes(browserName)) return null;
+
+    const versionSplit = browserVersion.split('-');
+    if (versionSplit.length === 1) return `${browserName}${browserVersion}`;
+
+    const [lower, upper] = versionSplit;
+    const lowerNum = Number(lower);
+    const upperNum = Number(upper);
+    let currentVersion = lowerNum;
+    let versionArray = [];
+    while (currentVersion < upperNum) {
+      versionArray.push(`${browserName}${currentVersion}`);
+      currentVersion = (currentVersion * 10 + 0.1 * 10) / 10;
+    }
+    versionArray.push(`${browserName}${upperNum}`);
+
+    return versionArray;
+  });
+
+  return transformedArray.flat().filter((item) => Boolean(item));
+};
+
+export default resolveTargets;

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,6 +22,22 @@ braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
+browserslist@^4.19.1:
+  version "4.19.1"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.19.1.tgz#4ac0435b35ab655896c31d53018b6dd5e9e4c9a3"
+  integrity sha512-u2tbbG5PdKRTUoctO3NBD8FQ5HdPh1ZXPHzp1rwaa5jTc+RV9/+RlWiAIKmjRPQF+xbGM9Kklj5bZQFa2s/38A==
+  dependencies:
+    caniuse-lite "^1.0.30001286"
+    electron-to-chromium "^1.4.17"
+    escalade "^3.1.1"
+    node-releases "^2.0.1"
+    picocolors "^1.0.0"
+
+caniuse-lite@^1.0.30001286:
+  version "1.0.30001300"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001300.tgz#11ab6c57d3eb6f964cba950401fd00a146786468"
+  integrity sha512-cVjiJHWGcNlJi8TZVKNMnvMid3Z3TTdDHmLDzlOdIiZq138Exvo0G+G0wTdVYolxKb4AYwC+38pxodiInVtJSA==
+
 chalk@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.0.0.tgz#bd96c6bb8e02b96e08c0c3ee2a9d90e050c7b832"
@@ -41,6 +57,11 @@ chalk@^5.0.0:
     readdirp "~3.6.0"
   optionalDependencies:
     fsevents "~2.3.2"
+
+electron-to-chromium@^1.4.17:
+  version "1.4.46"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.46.tgz#c88a6fedc766589826db0481602a888864ade1ca"
+  integrity sha512-UtV0xUA/dibCKKP2JMxOpDtXR74zABevuUEH4K0tvduFSIoxRVcYmQsbB51kXsFTX8MmOyWMt8tuZAlmDOqkrQ==
 
 esbuild-android-arm64@0.14.11:
   version "0.14.11"
@@ -161,6 +182,11 @@ esbuild@^0.14.11:
     esbuild-windows-64 "0.14.11"
     esbuild-windows-arm64 "0.14.11"
 
+escalade@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
+  integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
+
 fill-range@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
@@ -213,6 +239,11 @@ nanoid@^3.1.30:
   version "3.1.32"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.32.tgz#8f96069e6239cc0a9ae8c0d3b41a3b4933a88c0a"
   integrity sha512-F8mf7R3iT9bvThBoW4tGXhXFHCctyCiUUPrWF8WaTqa3h96d9QybkSeba43XVOOE3oiLfkVDe4bT8MeGmkrTxw==
+
+node-releases@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.1.tgz#3d1d395f204f1f2f29a54358b9fb678765ad2fc5"
+  integrity sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==
 
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"


### PR DESCRIPTION
This PR adds `browserslist` and a custom util to transform the output browsers array into an esbuild-compatible `target` array.